### PR TITLE
Added new service to create rigid bodies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(msg_files
   "msg/MarkerArray.msg"
   "msg/RigidBody.msg"
   "msg/RigidBodyArray.msg"
+  "srv/CreateRigidBody.srv"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/srv/CreateRigidBody.srv
+++ b/srv/CreateRigidBody.srv
@@ -1,0 +1,6 @@
+string rigid_body_name
+string link_parent
+int32[] markers
+
+---
+bool success


### PR DESCRIPTION
Service to create new rigid bodies with various markers. The parent link must be specified, from which it will take the orientation. The position will be the calculation of the centroid of all the added markers.